### PR TITLE
Refactor route configuration structure

### DIFF
--- a/App.tsx
+++ b/App.tsx
@@ -1,105 +1,51 @@
-import React, { useEffect } from 'react';
-import { Routes, Route, Navigate } from 'react-router-dom';
-import Layout from './components/layout/Layout';
-import Dashboard from './pages/Dashboard';
-import UsersPage from './pages/UsersPage';
-import MatriculaPage from './pages/MatriculaPage';
-import AcademicoPage from './pages/AcademicoPage';
-import AsistenciaPage from './pages/AsistenciaPage';
-import ComunicacionesPage from './pages/ComunicacionesPage';
-import ReportesPage from './pages/ReportesPage';
-import RecursosPage from './pages/RecursosPage';
-import AdminFinanzasPage from './pages/AdminFinanzasPage';
-import AyudaPage from './pages/AyudaPage';
-import QRScannerPage from './pages/QRScannerPage';
-import LoginPage from './pages/LoginPage';
+import { useEffect, type FC } from 'react';
+import { Navigate, Route, Routes } from 'react-router-dom';
+
 import AccessTypePage from './pages/AccessTypePage';
+import LoginPage from './pages/LoginPage';
+import { roleRouteConfig } from './routes/roleRoutes';
+import type { AppRole } from './routes/types';
 import { useAuthStore } from './store/authStore';
 import { useUIStore } from './store/uiStore';
-import PlaceholderPage from './pages/PlaceholderPage';
-import { Handshake } from 'lucide-react';
-import AvanceDocentesPage from './pages/AvanceDocentesPage';
-import MonitoreoCursosPage from './pages/MonitoreoCursosPage';
-import MonitoreoEstudiantesPage from './pages/MonitoreoEstudiantesPage';
-import ActasCertificadosPage from './pages/ActasCertificadosPage';
-import ReportesAcademicosPage from './pages/ReportesAcademicosPage';
-import ConfiguracionAcademicaPage from './pages/ConfiguracionAcademicaPage';
-import TeacherLayout from './components/layout/TeacherLayout';
-import TeacherDashboard from './pages/TeacherDashboard';
-import RegistrarNotasPage from './pages/RegistrarNotasPage';
-import LibroCalificacionesPage from './pages/LibroCalificacionesPage';
-import ConvivenciaPage from './pages/ConvivenciaPage';
-import SettingsPage from './pages/SettingsPage';
-import RolesPage from './pages/RolesPage';
-import ActivityLogPage from './pages/ActivityLogPage';
 
+const App: FC = () => {
+  const { isAuthenticated, user } = useAuthStore();
+  const { setTheme } = useUIStore();
 
-const DirectorRoutes = () => (
-  <Layout>
-    <Routes>
-      <Route path="/" element={<Dashboard />} />
-      <Route path="/usuarios" element={<UsersPage />} />
-      <Route path="/matricula" element={<MatriculaPage />} />
-      <Route path="/academico" element={<AcademicoPage />} />
-      <Route path="/academico/avance-docentes" element={<AvanceDocentesPage />} />
-      <Route path="/academico/monitoreo-cursos" element={<MonitoreoCursosPage />} />
-      <Route path="/academico/monitoreo-estudiantes" element={<MonitoreoEstudiantesPage />} />
-      <Route path="/academico/actas-certificados" element={<ActasCertificadosPage />} />
-      <Route path="/academico/reportes-descargas" element={<ReportesAcademicosPage />} />
-      <Route path="/academico/configuracion" element={<ConfiguracionAcademicaPage />} />
-      <Route path="/asistencia" element={<AsistenciaPage />} />
-      <Route path="/asistencia/scan" element={<QRScannerPage />} />
-      <Route path="/comunicaciones" element={<ComunicacionesPage />} />
-      <Route path="/reportes" element={<ReportesPage />} />
-      <Route path="/recursos" element={<RecursosPage />} />
-      <Route path="/admin" element={<AdminFinanzasPage />} />
-      <Route path="/settings" element={<SettingsPage />} />
-      <Route path="/settings/roles" element={<RolesPage />} />
-      <Route path="/settings/activity-log" element={<ActivityLogPage />} />
-      <Route path="/ayuda" element={<AyudaPage />} />
-      <Route path="/convivencia" element={<ConvivenciaPage />} />
-      <Route path="*" element={<Navigate to="/" />} />
-    </Routes>
-  </Layout>
-);
+  useEffect(() => {
+    const storedTheme = localStorage.getItem('theme');
+    const systemPrefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
 
-const TeacherRoutes = () => (
-    <TeacherLayout>
-        <Routes>
-            <Route path="/" element={<TeacherDashboard />} />
-            <Route path="/registrar-notas" element={<RegistrarNotasPage />} />
-            <Route path="/libro-calificaciones" element={<LibroCalificacionesPage />} />
-            <Route path="*" element={<Navigate to="/" />} />
-        </Routes>
-    </TeacherLayout>
-);
-
-
-const App: React.FC = () => {
-    const { isAuthenticated, user } = useAuthStore();
-    const { setTheme } = useUIStore();
-
-    useEffect(() => {
-        const storedTheme = localStorage.getItem('theme');
-        const systemPrefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches;
-        if (storedTheme === 'dark' || (!storedTheme && systemPrefersDark)) {
-            setTheme('dark');
-        } else {
-            setTheme('light');
-        }
-    }, [setTheme]);
-
-    if (!isAuthenticated) {
-        return (
-            <Routes>
-                <Route path="/login" element={<LoginPage />} />
-                <Route path="/access-type" element={<AccessTypePage />} />
-                <Route path="*" element={<Navigate to="/access-type" />} />
-            </Routes>
-        );
+    if (storedTheme === 'dark' || (!storedTheme && systemPrefersDark)) {
+      setTheme('dark');
+    } else {
+      setTheme('light');
     }
-    
-    return user?.role === 'director' ? <DirectorRoutes /> : <TeacherRoutes />;
+  }, [setTheme]);
+
+  if (!isAuthenticated) {
+    return (
+      <Routes>
+        <Route path="/login" element={<LoginPage />} />
+        <Route path="/access-type" element={<AccessTypePage />} />
+        <Route path="*" element={<Navigate to="/access-type" />} />
+      </Routes>
+    );
+  }
+
+  const role: AppRole = user?.role === 'teacher' ? 'teacher' : 'director';
+  const { layout: LayoutComponent, routes, fallback } = roleRouteConfig[role];
+
+  return (
+    <LayoutComponent>
+      <Routes>
+        {routes.map(({ path, Component }) => (
+          <Route key={path} path={path} element={<Component />} />
+        ))}
+        <Route path="*" element={<Navigate to={fallback} />} />
+      </Routes>
+    </LayoutComponent>
+  );
 };
 
 export default App;

--- a/routes/roleRoutes.tsx
+++ b/routes/roleRoutes.tsx
@@ -1,0 +1,67 @@
+import Layout from '../components/layout/Layout';
+import TeacherLayout from '../components/layout/TeacherLayout';
+import Dashboard from '../pages/Dashboard';
+import UsersPage from '../pages/UsersPage';
+import MatriculaPage from '../pages/MatriculaPage';
+import AcademicoPage from '../pages/AcademicoPage';
+import AvanceDocentesPage from '../pages/AvanceDocentesPage';
+import MonitoreoCursosPage from '../pages/MonitoreoCursosPage';
+import MonitoreoEstudiantesPage from '../pages/MonitoreoEstudiantesPage';
+import ActasCertificadosPage from '../pages/ActasCertificadosPage';
+import ReportesAcademicosPage from '../pages/ReportesAcademicosPage';
+import ConfiguracionAcademicaPage from '../pages/ConfiguracionAcademicaPage';
+import AsistenciaPage from '../pages/AsistenciaPage';
+import QRScannerPage from '../pages/QRScannerPage';
+import ComunicacionesPage from '../pages/ComunicacionesPage';
+import ReportesPage from '../pages/ReportesPage';
+import RecursosPage from '../pages/RecursosPage';
+import AdminFinanzasPage from '../pages/AdminFinanzasPage';
+import SettingsPage from '../pages/SettingsPage';
+import RolesPage from '../pages/RolesPage';
+import ActivityLogPage from '../pages/ActivityLogPage';
+import AyudaPage from '../pages/AyudaPage';
+import ConvivenciaPage from '../pages/ConvivenciaPage';
+import TeacherDashboard from '../pages/TeacherDashboard';
+import RegistrarNotasPage from '../pages/RegistrarNotasPage';
+import LibroCalificacionesPage from '../pages/LibroCalificacionesPage';
+
+import type { RoleRouteConfig } from './types';
+
+export const roleRouteConfig: RoleRouteConfig = {
+  director: {
+    layout: Layout,
+    fallback: '/',
+    routes: [
+      { path: '/', Component: Dashboard },
+      { path: '/usuarios', Component: UsersPage },
+      { path: '/matricula', Component: MatriculaPage },
+      { path: '/academico', Component: AcademicoPage },
+      { path: '/academico/avance-docentes', Component: AvanceDocentesPage },
+      { path: '/academico/monitoreo-cursos', Component: MonitoreoCursosPage },
+      { path: '/academico/monitoreo-estudiantes', Component: MonitoreoEstudiantesPage },
+      { path: '/academico/actas-certificados', Component: ActasCertificadosPage },
+      { path: '/academico/reportes-descargas', Component: ReportesAcademicosPage },
+      { path: '/academico/configuracion', Component: ConfiguracionAcademicaPage },
+      { path: '/asistencia', Component: AsistenciaPage },
+      { path: '/asistencia/scan', Component: QRScannerPage },
+      { path: '/comunicaciones', Component: ComunicacionesPage },
+      { path: '/reportes', Component: ReportesPage },
+      { path: '/recursos', Component: RecursosPage },
+      { path: '/admin', Component: AdminFinanzasPage },
+      { path: '/settings', Component: SettingsPage },
+      { path: '/settings/roles', Component: RolesPage },
+      { path: '/settings/activity-log', Component: ActivityLogPage },
+      { path: '/ayuda', Component: AyudaPage },
+      { path: '/convivencia', Component: ConvivenciaPage },
+    ],
+  },
+  teacher: {
+    layout: TeacherLayout,
+    fallback: '/',
+    routes: [
+      { path: '/', Component: TeacherDashboard },
+      { path: '/registrar-notas', Component: RegistrarNotasPage },
+      { path: '/libro-calificaciones', Component: LibroCalificacionesPage },
+    ],
+  },
+};

--- a/routes/types.ts
+++ b/routes/types.ts
@@ -1,0 +1,16 @@
+import type { ComponentType, ReactNode } from 'react';
+
+export type AppRole = 'director' | 'teacher';
+
+export interface RouteDefinition {
+  path: string;
+  Component: ComponentType;
+}
+
+export interface RoleRouteGroup {
+  layout: ComponentType<{ children: ReactNode }>;
+  routes: RouteDefinition[];
+  fallback: string;
+}
+
+export type RoleRouteConfig = Record<AppRole, RoleRouteGroup>;


### PR DESCRIPTION
## Summary
- centralize role-based routes in a shared configuration to keep modules organized
- simplify `App` to render role layouts from the route map while preserving theme detection logic

## Testing
- npm run build

------
https://chatgpt.com/codex/tasks/task_b_68cf1c6746a8832993dce6c104ccfbc2